### PR TITLE
start-remote: Easily fetch the latest scripts and run the active scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ Please minimize spoilers as much as possible. The Bitburner editor has autocompl
 1. The goal is track the changes that are made to these scripts over time.
 2. It would be nice to not to lose anything in case a regression occurs.
 3. Sharing these scripts might allow for idea exchange.
+
+## Quick Start
+From the Bitburner terminal:
+1. wget https://raw.githubusercontent.com/jrchamp/bitburner-scripts/main/start-remote.js start-remote.js
+2. run start-remote.js

--- a/deploy-hack.js
+++ b/deploy-hack.js
@@ -134,12 +134,13 @@ export async function main(ns) {
 
 				let taskStats = {};
 				for (const taskType in tasks) {
-					// Determine the number of threads to run of each process.
-					availableRam = server.maxRam - ns.getServerUsedRam(hostname);
+					// Determine the amount of available RAM (minus a safety buffer).
+					availableRam = server.maxRam - ns.getServerUsedRam(hostname) - 0.05;
 
 					script = tasks[taskType];
 					scriptRam = ns.getScriptRam(script);
 
+					// Determine the number of threads to run of each process.
 					let totalThreads = Math.floor(taskRatios[taskType] * availableRam / scriptRam);
 
 					if (totalThreads > 0) {

--- a/start-remote.js
+++ b/start-remote.js
@@ -1,0 +1,37 @@
+/** @param {NS} ns **/
+export async function main(ns) {
+	ns.disableLog('disableLog');
+
+	// TODO: Consider having this available as deploy.json.
+	let files = {
+		// Support scripts.
+		'install-backdoor.js': false,
+		'max-hacknet.js': false,
+		'shared-functions.js': false,
+		'status-targets.js': false,
+		'task-grow.js': false,
+		'task-hack.js': false,
+		'task-weaken.js': false,
+		'workflow-hack.js': false,
+
+		// Active scripts (order matters).
+		'cache-servers.js': true,
+		'purchase-servers.js': true,
+		'deploy-hack.js': true,
+	};
+
+	let baseUrl = 'https://raw.githubusercontent.com/jrchamp/bitburner-scripts/main/';
+	if (ns.args.length > 0) {
+		baseUrl = ns.args[0];
+	}
+
+	for (const filename in files) {
+		let url = baseUrl + filename;
+		await ns.wget(url, filename, 'home');
+		ns.toast('wget ' + filename, 'success', 10000);
+		if (files[filename] === true) {
+			ns.exec(filename, 'home');
+			ns.toast('Exec ' + filename, 'success', 10000);
+		}
+	}
+}


### PR DESCRIPTION
The initial memory requirement might be higher than the starting memory amount, so there may be some work to do. I tried using `ns.atExit()` to avoid the overhead, but it threw an exception without any details...