### PR TITLE
cache servers: Convert to exported function and use in deploy-hack.js

### DIFF
--- a/cache-servers.js
+++ b/cache-servers.js
@@ -6,6 +6,20 @@ var cache = [];
 /** @param {NS} ns **/
 export async function main(ns) {
 	ns.disableLog('disableLog');
+	ns.disableLog('sleep');
+
+	while (true) {
+		await cacheServers(ns);
+
+		await ns.sleep(10000);
+	}
+}
+
+/**
+ * @param {NS} ns
+ */
+export async function cacheServers(ns) {
+	ns.disableLog('disableLog');
 	ns.disableLog('getHackingLevel');
 	ns.disableLog('getServerMaxMoney');
 	ns.disableLog('getServerMinSecurityLevel');
@@ -14,33 +28,28 @@ export async function main(ns) {
 	ns.disableLog('getServerMaxRam');
 	ns.disableLog('scan');
 	ns.disableLog('scp');
-	ns.disableLog('sleep');
 
 	let file = getServersCacheFilename(ns);
-	while (true) {
-		ns.print('Building server cache');
-		cached = {};
-		cache = [];
-		scan_all(ns, '', ['home']);
-		cache.sort(function (a, b) {
-			return b.ratio - a.ratio;
-		});
-		let data = JSON.stringify(cache);
-		await ns.write(file, data, 'w');
-		ns.print('Total servers cached: ' + cache.length);
+	ns.print('Building server cache');
+	cached = {};
+	cache = [];
+	scan_all(ns, '', ['home']);
+	cache.sort(function (a, b) {
+		return b.ratio - a.ratio;
+	});
+	let data = JSON.stringify(cache);
+	await ns.write(file, data, 'w');
+	ns.print('Total servers cached: ' + cache.length);
 
-		let count = 0;	
-		for (let i = 0; i < cache.length; i++) {
-			let server = cache[i];
-			if (server.host !== 'home' && server.hasRoot) {
-				await ns.scp(file, 'home', server.host);
-				count++;
-			}
+	let count = 0;	
+	for (let i = 0; i < cache.length; i++) {
+		let server = cache[i];
+		if (server.host !== 'home' && server.hasRoot) {
+			await ns.scp(file, 'home', server.host);
+			count++;
 		}
-		ns.print('Deployed server cache to ' + count + ' systems');
-	
-		await ns.sleep(10000);
 	}
+	ns.print('Deployed server cache to ' + count + ' systems');
 }
 
 /**

--- a/deploy-hack.js
+++ b/deploy-hack.js
@@ -1,13 +1,11 @@
 import { getServersCacheFilename, getCachedServers, getTargetLimit } from 'shared-functions.js';
+import { cacheServers } from 'cache-servers.js';
 
 /** @param {NS} ns **/
 export async function main(ns) {
 	ns.disableLog('disableLog');
-	ns.disableLog('getServerRequiredHackingLevel');
 	ns.disableLog('getHackingLevel');
-	ns.disableLog('getServerNumPortsRequired');
 	ns.disableLog('getScriptRam');
-	ns.disableLog('getServerMaxRam');
 	ns.disableLog('getServerUsedRam');
 	ns.disableLog('exec');
 	ns.disableLog('scriptKill');
@@ -45,6 +43,10 @@ export async function main(ns) {
 	}
 
 	while (true) {
+		// Caching the servers as part of this script saves 2.25 GB.
+		await cacheServers(ns);
+
+		let hack_skill = ns.getHackingLevel();
 		let servers = await getCachedServers(ns);
 		let tohack = [];
 		for (let i = 0; i < servers.length; i++) {
@@ -56,7 +58,6 @@ export async function main(ns) {
 				tohack.push(server);
 
 				let hack_required = server.requiredHackingLevel;
-				let hack_skill = ns.getHackingLevel();
 				let serverStatus = hostname + ' - ' + hack_skill + '/' + hack_required + ': ' + (Math.floor(10000 * hack_skill / hack_required) / 100) + '%';
 				if (hack_skill < hack_required) {
 					ns.print('Waiting to attack: ' + serverStatus);
@@ -175,6 +176,6 @@ export async function main(ns) {
 			}
 		}
 		ns.print('Remaining targets: ' + tohack.length);
-		await ns.sleep(30000);
+		await ns.sleep(15000);
 	}
 }

--- a/start-remote.js
+++ b/start-remote.js
@@ -16,9 +16,9 @@ export async function main(ns) {
 		'task-weaken.js': false,
 		'task-share.js': false,
 		'workflow-hack.js': false,
+		'cache-servers.js': false,
 
 		// Active scripts (order matters).
-		'cache-servers.js': true,
 		'purchase-servers.js': true,
 		'deploy-hack.js': true,
 	};


### PR DESCRIPTION
Saves 2.25 GB of memory (both scripts were paying for `baseCost` + `scp` + `getHackingLevel`) and also addresses the minor cache / deploy server memory mismatch issue.